### PR TITLE
test: add lazy logging coverage

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/pytest.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: |
+          python -m pytest
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"

--- a/tests/test_lazy_logger.py
+++ b/tests/test_lazy_logger.py
@@ -1,0 +1,96 @@
+import asyncio
+import logging
+
+from lazy_logging import LazyLogger, LazyLoggerFactory
+
+
+def _make_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    logger.setLevel(logging.NOTSET)
+    return logger
+
+
+def _messages_for(logger_name: str, records) -> list[str]:
+    return [record.getMessage() for record in records if record.name == logger_name]
+
+
+def test_lazy_logger_logs_with_env_level(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.sync")
+    monkeypatch.setenv("LL_LEVEL_TEST", "DEBUG")
+
+    @LazyLogger(logger, "TEST")
+    def add(a, b):
+        return a + b
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = add(1, 2)
+
+    assert result == 3
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 3" in message for message in messages)
+
+
+def test_lazy_logger_factory_key_and_level(monkeypatch):
+    monkeypatch.setenv("LL_LEVEL_EXAMPLE", "INFO")
+    factory = LazyLoggerFactory("EXAMPLE")
+    logger = _make_logger("lazy_logging.test.factory")
+    lazy_logger = factory(logger)
+
+    assert lazy_logger.key == "LL_LEVEL_EXAMPLE"
+    assert lazy_logger.log_level == logging.INFO
+
+
+def test_lazy_logger_async_function(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.async")
+    monkeypatch.setenv("LL_LEVEL_ASYNC", "DEBUG")
+
+    @LazyLogger(logger, "ASYNC")
+    async def work(value):
+        await asyncio.sleep(0)
+        return value + 1
+
+    async def runner():
+        return await work(2)
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = asyncio.run(runner())
+
+    assert result == 3
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 3" in message for message in messages)
+
+
+def test_lazy_logger_async_descriptor(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.descriptor")
+    monkeypatch.setenv("LL_LEVEL_DESC", "DEBUG")
+    lazy_logger = LazyLogger(logger, "DESC")
+
+    class AsyncDescriptor:
+        async def __get__(self, instance, owner):
+            await asyncio.sleep(0)
+            return instance.value
+
+    descriptor = AsyncDescriptor()
+    descriptor.__name__ = "AsyncDescriptor"
+
+    class Thing:
+        data = lazy_logger(descriptor)
+
+        def __init__(self, value):
+            self.value = value
+
+    async def runner():
+        thing = Thing(5)
+        return await thing.data
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = asyncio.run(runner())
+
+    assert result == 5
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 5" in message for message in messages)


### PR DESCRIPTION
## Summary
- add pytest coverage for sync, async, and descriptor logging
- assert env-driven log levels and emitted debug messages

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest`
