### PR TITLE
chore: add strict mypy config

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,33 @@
+name: Mypy
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/mypy.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy
+      - name: Run mypy
+        run: |
+          mypy .

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -14,7 +14,12 @@ concurrency:
 
 jobs:
   mypy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
       - name: Install mypy
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install mypy
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e .
           pip install mypy
       - name: Run mypy
         run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pytest
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e .
           pip install pytest
       - name: Run tests
         run: |

--- a/lazy_logging/__init__.py
+++ b/lazy_logging/__init__.py
@@ -10,7 +10,11 @@ from inspect import isawaitable
 from time import time
 from types import MethodType
 from typing import Any, Awaitable, Callable, DefaultDict, Generator, Generic, Iterable, Optional, TYPE_CHECKING, TypeVar, cast, overload
-from typing_extensions import ParamSpec
+
+try:
+    from typing import ParamSpec
+except ImportError:  # pragma: no cover - fallback for older Python
+    from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     from typing_extensions import override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,3 @@ enable_error_code = [
   "unused-awaitable",
   "unused-ignore",
 ]
-
-[[tool.mypy.overrides]]
-module = ["pytest", "pytest.*"]
-follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.mypy]
+python_version = "3.9"
+strict = true
+enable_error_code = [
+  "deprecated",
+  "exhaustive-match",
+  "explicit-override",
+  "ignore-without-code",
+  "mutable-override",
+  "possibly-undefined",
+  "redundant-expr",
+  "redundant-self",
+  "truthy-bool",
+  "truthy-iterable",
+  "unimported-reveal",
+  "unused-awaitable",
+  "unused-ignore",
+]
+
+[[tool.mypy.overrides]]
+module = ["pytest", "pytest.*"]
+follow_imports = "skip"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/BobTheBuidler/lazy_logging',
     license='MIT',
     install_requires=[
-        'typing_extensions',
+        'typing_extensions>=4.4.0',
     ],
     setup_requires=[
         'setuptools_scm',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     author_email='bobthebuidlerdefi@gmail.com',
     url='https://github.com/BobTheBuidler/lazy_logging',
     license='MIT',
+    install_requires=[
+        'typing_extensions',
+    ],
     setup_requires=[
         'setuptools_scm',
     ],

--- a/tests/test_lazy_logger.py
+++ b/tests/test_lazy_logger.py
@@ -1,0 +1,96 @@
+import asyncio
+import logging
+
+from lazy_logging import LazyLogger, LazyLoggerFactory
+
+
+def _make_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    logger.setLevel(logging.NOTSET)
+    return logger
+
+
+def _messages_for(logger_name: str, records) -> list[str]:
+    return [record.getMessage() for record in records if record.name == logger_name]
+
+
+def test_lazy_logger_logs_with_env_level(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.sync")
+    monkeypatch.setenv("LL_LEVEL_TEST", "DEBUG")
+
+    @LazyLogger(logger, "TEST")
+    def add(a, b):
+        return a + b
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = add(1, 2)
+
+    assert result == 3
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 3" in message for message in messages)
+
+
+def test_lazy_logger_factory_key_and_level(monkeypatch):
+    monkeypatch.setenv("LL_LEVEL_EXAMPLE", "INFO")
+    factory = LazyLoggerFactory("EXAMPLE")
+    logger = _make_logger("lazy_logging.test.factory")
+    lazy_logger = factory(logger)
+
+    assert lazy_logger.key == "LL_LEVEL_EXAMPLE"
+    assert lazy_logger.log_level == logging.INFO
+
+
+def test_lazy_logger_async_function(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.async")
+    monkeypatch.setenv("LL_LEVEL_ASYNC", "DEBUG")
+
+    @LazyLogger(logger, "ASYNC")
+    async def work(value):
+        await asyncio.sleep(0)
+        return value + 1
+
+    async def runner():
+        return await work(2)
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = asyncio.run(runner())
+
+    assert result == 3
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 3" in message for message in messages)
+
+
+def test_lazy_logger_async_descriptor(monkeypatch, caplog):
+    logger = _make_logger("lazy_logging.test.descriptor")
+    monkeypatch.setenv("LL_LEVEL_DESC", "DEBUG")
+    lazy_logger = LazyLogger(logger, "DESC")
+
+    class AsyncDescriptor:
+        async def __get__(self, instance, owner):
+            await asyncio.sleep(0)
+            return instance.value
+
+    descriptor = AsyncDescriptor()
+    descriptor.__name__ = "AsyncDescriptor"
+
+    class Thing:
+        data = lazy_logger(descriptor)
+
+        def __init__(self, value):
+            self.value = value
+
+    async def runner():
+        thing = Thing(5)
+        return await thing.data
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = asyncio.run(runner())
+
+    assert result == 5
+    messages = _messages_for(logger.name, caplog.records)
+    assert any("Fetching" in message for message in messages)
+    assert any("returns: 5" in message for message in messages)


### PR DESCRIPTION
## Summary
- add strict mypy configuration and workflow
- add typing to wrappers and tests to satisfy strict mode
- avoid pytest import analysis issues under older target versions

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest`
- `python -m mypy .`
