### PR TITLE
chore: update AGENTS guidance for CI and config centralization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,9 @@ All agents must follow these rules:
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
 8) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
+9) Maximize the use of caching in GitHub workflow files to minimize run duration.
+10) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
+11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
+12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Update AGENTS.md to add guidance for workflow caching and workflow paths filtering.
- Update AGENTS.md to centralize mypy configuration guidance.
- Update AGENTS.md to centralize pytest configuration guidance.

Rationale:
- Keep CI behavior and test/type-check configs consistent across contributions.

Details:
- Document workflow caching guidance in AGENTS.md.
- Document workflow paths filtering guidance in AGENTS.md.
- Specify centralized mypy and pytest config expectations in AGENTS.md.