### PR TITLE
docs: add AGENTS mypy config rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,6 @@ All agents must follow these rules:
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
 8) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
+9) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Add the AGENTS rule centralizing mypy configuration in pyproject.toml.

Rationale
- Keep type-checking configuration consistent and avoid drift across tooling.

Details
- Update `AGENTS.md` only.