### PR TITLE
fix(cicd): cache python deps in CI workflows

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            setup.py
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            setup.py
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,12 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: "pip"
+        cache-dependency-path: |
+          pyproject.toml
+          setup.py
     - name: Install dependencies
       run: python -m pip install --upgrade pip setuptools wheel twine
     - name: Build and publish


### PR DESCRIPTION
Summary:
- Enable pip caching for pytest, mypy, and release workflows.

Rationale:
- Speed up dependency installs and reduce CI duration.

Details:
- Added `actions/setup-python` cache configuration with dependency paths.
- Tests: `pytest`.